### PR TITLE
Update deploy.sh

### DIFF
--- a/packages/contract/script/deploy.sh
+++ b/packages/contract/script/deploy.sh
@@ -9,6 +9,30 @@ source ../common/wallet.sh
 CONTRACT_PATH="src/Counter.sol:Counter"
 DEPLOY_FILE="out/deploy.txt"
 
+check_dependencies() {
+    echo -e "${BLUE}Checking system dependencies...${NC}"
+
+    missing_libs=()
+
+    for lib in "GLIBC_2.34" "GLIBC_2.32" "GLIBC_2.33" "CXXABI_1.3.13" "GLIBCXX_3.4.29"; do
+        if ! strings /lib/x86_64-linux-gnu/libc.so.6 | grep -q "$lib" && \
+           ! strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep -q "$lib"; then
+            missing_libs+=("$lib")
+        fi
+    done
+
+    if [ ${#missing_libs[@]} -ne 0 ]; then
+        echo -e "${RED}Missing or outdated dependencies detected:${NC}"
+        for lib in "${missing_libs[@]}"; do
+            echo -e "${RED}- $lib${NC}"
+        done
+        echo -e "${RED}Please update your system libraries before proceeding.${NC}"
+        exit 1
+    else
+        echo -e "${GREEN}All dependencies are satisfied.${NC}"
+    fi
+}
+
 prelude() {
     echo -e "${BLUE}Deploy an encrypted contract in <1m.${NC}"
     echo -e "It's a Counter contract that only reveals the counter once it's >=5."
@@ -16,6 +40,7 @@ prelude() {
     read -r
 }
 
+check_dependencies
 prelude
 
 dev_wallet


### PR DESCRIPTION
Ubuntu 20 - 

GLIBC_2.34

GLIBC_2.32

GLIBC_2.33

CXXABI_1.3.13

GLIBCXX_3.4.29 - errors.

Why Does This Happen?
The error occurs because your Solidity compiler (solc) relies on system libraries such as GLIBC and libstdc++. Older versions of Ubuntu (e.g., Ubuntu 20.04) may have outdated versions of these libraries, leading to compatibility issues.

What Has Been Added?

Dependency Check:

The script now verifies if required versions of GLIBC and libstdc++ are installed.

If any are missing, the script displays the missing libraries.

Suggested Fixes:

If dependencies are outdated, the script provides installation commands to update them.

Example:

sudo apt update && sudo apt install -y libc6

Automatic Exit:

If any dependency is missing, the script stops before attempting to deploy the contract.

![image](https://github.com/user-attachments/assets/3f760125-4ae9-45ab-ad03-57f3beeb2fd5)
