### PR TITLE
fix(wallet): replace deprecated scast with cast

### DIFF
--- a/packages/common/wallet.sh
+++ b/packages/common/wallet.sh
@@ -25,7 +25,7 @@ check_balance() {
 dev_wallet() {
     print_step "1" "Generating new dev wallet"
     # CAUTION: DO NOT GENERATE A KEYPAIR LIKE THIS FOR PRODUCTION
-    local keypair=$(scast wallet new)
+    local keypair=$(cast wallet new)
     DEV_WALLET_ADDRESS=$(echo "$keypair" | grep "Address:" | awk '{print $2}')
     DEV_WALLET_PRIVKEY=$(echo "$keypair" | grep "Private key:" | awk '{print $3}')
     if [ -z "$DEV_WALLET_ADDRESS" ]; then


### PR DESCRIPTION
The `scast` command used in `wallet.sh` is no longer available in the latest Seismic Foundry setup.

This PR replaces `scast wallet new` with `cast wallet new`, using the standard Foundry CLI (`cast`) which is still maintained and supported.

Tested with:
- `foundryup` installed
- `cast` available in ~/.foundry/bin
- Successfully generated new dev wallet

This resolves the issue where wallet creation fails with "scast: command not found".

